### PR TITLE
[Feature] 카카오 로그인 및 마이페이지 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,22 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,18 @@ dependencies {
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+	//querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
+
+//자동 생성된 Q클래스 gradle clean으로 제거
+clean {
+	delete file('src/main/generated')
+}
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/goorm/LocC/TestController.java
+++ b/src/main/java/com/goorm/LocC/TestController.java
@@ -1,45 +1,45 @@
-package com.goorm.LocC;
-
-import com.goorm.LocC.global.common.dto.ApiResponse;
-import com.goorm.LocC.member.exception.MemberException;
-import com.goorm.LocC.store.domain.Category;
-import com.goorm.LocC.store.domain.City;
-import com.goorm.LocC.store.domain.Province;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
-
-import static com.goorm.LocC.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
-
-@RestController
-public class TestController {
-
-    @PostMapping("/province")
-    public ResponseEntity<ApiResponse<Province>> test(
-            @RequestBody Province province
-            ) {
-        return ResponseEntity.ok(ApiResponse.success(province));
-    }
-
-    @PostMapping("/category")
-    public ResponseEntity<ApiResponse<Category>> test2(
-            @RequestBody Category category
-    ) {
-        return ResponseEntity.ok(ApiResponse.success(category));
-    }
-
-    @PostMapping("/city")
-    public ResponseEntity<ApiResponse<City>> test3(
-            @RequestBody City city
-    ) {
-        return ResponseEntity.ok(ApiResponse.success(city));
-    }
-
-    @GetMapping("/test")
-    public ResponseEntity<ApiResponse<City>> test4(
-    ) {
-        throw new MemberException(MEMBER_NOT_FOUND);
-    }
-}
+//package com.goorm.LocC;
+//
+//import com.goorm.LocC.global.common.dto.ApiResponse;
+//import com.goorm.LocC.member.exception.MemberException;
+//import com.goorm.LocC.store.domain.Category;
+//import com.goorm.LocC.store.domain.City;
+//import com.goorm.LocC.store.domain.Province;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import static com.goorm.LocC.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+//
+//@RestController
+//public class TestController {
+//
+//    @PostMapping("/province")
+//    public ResponseEntity<ApiResponse<Province>> test(
+//            @RequestBody Province province
+//            ) {
+//        return ResponseEntity.ok(ApiResponse.success(province));
+//    }
+//
+//    @PostMapping("/category")
+//    public ResponseEntity<ApiResponse<Category>> test2(
+//            @RequestBody Category category
+//    ) {
+//        return ResponseEntity.ok(ApiResponse.success(category));
+//    }
+//
+//    @PostMapping("/city")
+//    public ResponseEntity<ApiResponse<City>> test3(
+//            @RequestBody City city
+//    ) {
+//        return ResponseEntity.ok(ApiResponse.success(city));
+//    }
+//
+//    @GetMapping("/test")
+//    public ResponseEntity<ApiResponse<City>> test4(
+//    ) {
+//        throw new MemberException(MEMBER_NOT_FOUND);
+//    }
+//}

--- a/src/main/java/com/goorm/LocC/auth/application/AuthService.java
+++ b/src/main/java/com/goorm/LocC/auth/application/AuthService.java
@@ -1,0 +1,28 @@
+package com.goorm.LocC.auth.application;
+
+import com.goorm.LocC.auth.dto.KakaoInfoDto;
+import com.goorm.LocC.auth.dto.TokenRespDto;
+import com.goorm.LocC.auth.jwt.utils.JwtUtil;
+import com.goorm.LocC.member.domain.Member;
+import com.goorm.LocC.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class AuthService {
+
+    private final KakaoAuthService kakaoAuthService;
+    private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
+
+    public TokenRespDto kakaoLogin(String kakaoAccessToken) {
+        KakaoInfoDto kakaoInfo = kakaoAuthService.getKakaoInfo(kakaoAccessToken);
+        Member member = memberRepository.findBySocialId(kakaoInfo.getSocialId())
+                .orElseGet(() -> memberRepository.save(kakaoInfo.toEntity()));
+
+        return jwtUtil.issueAccessToken(member.getEmail(), member.getUsername());
+    }
+}

--- a/src/main/java/com/goorm/LocC/auth/application/KakaoAuthService.java
+++ b/src/main/java/com/goorm/LocC/auth/application/KakaoAuthService.java
@@ -1,0 +1,69 @@
+package com.goorm.LocC.auth.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goorm.LocC.auth.dto.KakaoInfoDto;
+import com.goorm.LocC.auth.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static com.goorm.LocC.auth.exception.AuthErrorCode.*;
+import static com.goorm.LocC.auth.utils.KakaoProperties.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KakaoAuthService {
+
+    public KakaoInfoDto getKakaoInfo(String socialAccessToken) {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(AUTHORIZATION_HEADER,  socialAccessToken);
+
+            HttpEntity<JsonNode> httpEntity = new HttpEntity<>(headers);
+
+            ResponseEntity<String> responseData = restTemplate
+                    .postForEntity(USER_INFO_URL, httpEntity, String.class);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(responseData.getBody());
+
+            String id = jsonNode.get(ID).asText();
+            JsonNode kakaoAccountNode = jsonNode.get(ACCOUNT);
+            String nickname = kakaoAccountNode.get(PROFILE).get(NICKNAME).asText();
+            String email = kakaoAccountNode.get(EMAIL).asText();
+            String profileImageUrl = Optional.ofNullable(
+                    kakaoAccountNode
+                            .get(PROFILE)
+                            .get(PROFILE_IMAGE_URL))
+                    .map(JsonNode::asText)
+                    .orElse(
+                        // TODO: 프로필 이미지가 없을 경우 기본 이미지 URL 리턴
+                            ""
+                    );
+
+            return KakaoInfoDto.builder()
+                    .socialId(id)
+                    .email(email)
+                    .nickname(nickname)
+                    .profileImageUrl(profileImageUrl)
+                    .build();
+        } catch (HttpClientErrorException e) {
+            log.warn("Invalid Kakao Token: {}", e.getMessage());
+            throw new AuthException(KAKAO_INVALID_TOKEN);
+        } catch (Exception e) {
+            log.warn("Unexpected Kakao API Error: {}", e.getMessage());
+            throw new AuthException(KAKAO_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/goorm/LocC/auth/dto/CustomUserDetails.java
+++ b/src/main/java/com/goorm/LocC/auth/dto/CustomUserDetails.java
@@ -1,0 +1,35 @@
+package com.goorm.LocC.auth.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+	private final String email;
+	private final String username;
+	private final String authority;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		Collection<GrantedAuthority> collection = new ArrayList<>();
+		collection.add((GrantedAuthority) () -> authority);
+		return collection;
+	}
+
+	@Override
+	public String getPassword() {
+		return "";
+	}
+
+	@Override
+	public String getUsername() {
+		return username;
+	}
+}

--- a/src/main/java/com/goorm/LocC/auth/dto/KakaoInfoDto.java
+++ b/src/main/java/com/goorm/LocC/auth/dto/KakaoInfoDto.java
@@ -1,0 +1,37 @@
+package com.goorm.LocC.auth.dto;
+
+import com.goorm.LocC.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.goorm.LocC.member.domain.SocialType.KAKAO;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KakaoInfoDto {
+
+    private String socialId;
+    private String nickname;
+    private String email;
+    private String profileImageUrl;
+
+    @Builder
+    public KakaoInfoDto(String socialId, String nickname, String email, String profileImageUrl) {
+        this.socialId = socialId;
+        this.nickname = nickname;
+        this.email = email;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .socialType(KAKAO)
+                .socialId(socialId)
+                .username(nickname)
+                .email(email)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/goorm/LocC/auth/dto/TokenRespDto.java
+++ b/src/main/java/com/goorm/LocC/auth/dto/TokenRespDto.java
@@ -1,0 +1,28 @@
+package com.goorm.LocC.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TokenRespDto {
+
+    @Schema(description = "닉네임", example = "구름")
+    private String username;
+    @Schema(description = "이메일", example = "test@test.ac.kr")
+    private String email;
+    @Schema(description = "jwt access 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdW")
+    private String accessToken;
+
+    @Builder
+
+    public TokenRespDto(String username, String email, String accessToken) {
+        this.username = username;
+        this.email = email;
+        this.accessToken = accessToken;
+    }
+}
+

--- a/src/main/java/com/goorm/LocC/auth/dto/TokenRespDto.java
+++ b/src/main/java/com/goorm/LocC/auth/dto/TokenRespDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class TokenRespDto {
 
-    @Schema(description = "닉네임", example = "구름")
+    @Schema(description = "닉네임", example = "미르미0303")
     private String username;
     @Schema(description = "이메일", example = "test@test.ac.kr")
     private String email;
@@ -18,7 +18,6 @@ public class TokenRespDto {
     private String accessToken;
 
     @Builder
-
     public TokenRespDto(String username, String email, String accessToken) {
         this.username = username;
         this.email = email;

--- a/src/main/java/com/goorm/LocC/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/goorm/LocC/auth/exception/AuthErrorCode.java
@@ -1,0 +1,21 @@
+package com.goorm.LocC.auth.exception;
+
+import com.goorm.LocC.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+	KAKAO_INVALID_TOKEN(UNAUTHORIZED, "AUTH_401_0", "잘못된 카카오 엑세스 토큰입니다."),
+	KAKAO_API_ERROR(INTERNAL_SERVER_ERROR, "AUTH_500_0", "카카오 API 에러가 발생했습니다. 관리자에게 문의주세요."),
+	;
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/goorm/LocC/auth/exception/AuthException.java
+++ b/src/main/java/com/goorm/LocC/auth/exception/AuthException.java
@@ -1,0 +1,13 @@
+package com.goorm.LocC.auth.exception;
+
+import com.goorm.LocC.global.exception.BaseException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class AuthException extends BaseException {
+
+	public AuthException(AuthErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/goorm/LocC/auth/exception/JwtErrorCode.java
+++ b/src/main/java/com/goorm/LocC/auth/exception/JwtErrorCode.java
@@ -1,0 +1,23 @@
+package com.goorm.LocC.auth.exception;
+
+import com.goorm.LocC.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum JwtErrorCode implements BaseErrorCode {
+
+	EXPIRED_TOKEN(UNAUTHORIZED, "JWT_401_0", "토큰이 만료되었습니다."),
+	INVALID_TOKEN(UNAUTHORIZED, "JWT_401_1", "잘못된 토큰입니다."),
+	UNAUTHORIZED_ACCESS(UNAUTHORIZED, "JWT_401_2", "사용자 인증이 필요합니다."),
+	ACCESS_DENIED(FORBIDDEN, "JWT_403_0", "해당 요청에 대한 접근 권한이 없습니다."),
+	JWT_ERROR(INTERNAL_SERVER_ERROR, "JWT_500_0", "JWT 에러가 발생하였습니다. 관리자에게 문의주세요.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/goorm/LocC/auth/exception/JwtException.java
+++ b/src/main/java/com/goorm/LocC/auth/exception/JwtException.java
@@ -1,0 +1,13 @@
+package com.goorm.LocC.auth.exception;
+
+import com.goorm.LocC.global.exception.BaseException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class JwtException extends BaseException {
+
+	public JwtException(JwtErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/goorm/LocC/auth/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/goorm/LocC/auth/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.goorm.LocC.auth.jwt;
+
+import com.goorm.LocC.global.common.dto.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.goorm.LocC.auth.exception.JwtErrorCode.ACCESS_DENIED;
+
+/**
+ * 인가(Authorization) 예외가 발생했을 때 예외 처리 -> 인증된 사용자가 필요한 권한없이 접근하려고 하는 경우
+ */
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		log.warn("Authorization Exception: {}", accessDeniedException.getMessage());
+
+		ResponseEntity<ApiResponse<Void>> responseEntity = ACCESS_DENIED.toResponseEntity();
+	}
+}

--- a/src/main/java/com/goorm/LocC/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/goorm/LocC/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.goorm.LocC.auth.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.goorm.LocC.auth.exception.JwtErrorCode.UNAUTHORIZED_ACCESS;
+import static com.goorm.LocC.global.common.utils.JsonResponseUtil.*;
+
+/**
+ * 인증(Authentication) 예외가 발생했을 때 예외 처리 -> 인증되지 않은 사용자가 접근하려고 하는 경우
+ */
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+		log.warn("Authentication Exception: {}", authException.getMessage());
+
+		sendJsonResponse(response,
+				HttpStatus.UNAUTHORIZED,
+				UNAUTHORIZED_ACCESS.toApiResponse());
+	}
+}

--- a/src/main/java/com/goorm/LocC/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/goorm/LocC/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package com.goorm.LocC.auth.jwt.filter;
+
+
+import com.goorm.LocC.auth.jwt.utils.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+									FilterChain filterChain) throws ServletException, IOException {
+
+		String token = jwtUtil.extractToken(request);
+
+		if (token != null) {
+			Claims claims = jwtUtil.validateTokenAndGetClaims(token);
+			Authentication authentication = jwtUtil.getAuthentication(claims);
+
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/com/goorm/LocC/auth/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/goorm/LocC/auth/jwt/filter/JwtExceptionFilter.java
@@ -1,0 +1,46 @@
+package com.goorm.LocC.auth.jwt.filter;
+
+import com.goorm.LocC.auth.exception.JwtErrorCode;
+import com.goorm.LocC.auth.exception.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.goorm.LocC.global.common.utils.JsonResponseUtil.sendJsonResponse;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+
+@Slf4j
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (JwtException e) {
+			log.warn("Custom Jwt Exception: {}", e.getMessage());
+
+			sendJsonResponse(
+				response,
+				e.getErrorCode().getStatus(),
+				e.getErrorCode().toApiResponse()
+			);
+		} catch (Exception e) {
+			log.error("Jwt Exception: {}", e.getMessage());
+
+			sendJsonResponse(
+					response,
+					INTERNAL_SERVER_ERROR,
+					JwtErrorCode.JWT_ERROR.toApiResponse()
+			);
+		}
+	}
+}

--- a/src/main/java/com/goorm/LocC/auth/jwt/utils/JwtProperties.java
+++ b/src/main/java/com/goorm/LocC/auth/jwt/utils/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.goorm.LocC.auth.jwt.utils;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+
+    private String secretKey;
+    private Long accessExpirationTime;
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+}

--- a/src/main/java/com/goorm/LocC/auth/jwt/utils/JwtUtil.java
+++ b/src/main/java/com/goorm/LocC/auth/jwt/utils/JwtUtil.java
@@ -1,0 +1,118 @@
+package com.goorm.LocC.auth.jwt.utils;
+
+import com.goorm.LocC.auth.dto.CustomUserDetails;
+import com.goorm.LocC.auth.dto.TokenRespDto;
+import com.goorm.LocC.auth.exception.JwtErrorCode;
+import com.goorm.LocC.auth.exception.JwtException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.util.Date;
+
+import static com.goorm.LocC.member.domain.Role.USER;
+
+
+/**
+ * JWT 토큰 생성 및 검증
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtUtil {
+
+	private final JwtProperties jwtProperties;
+	private SecretKey secretKey;
+
+	@PostConstruct
+	public void initializeSecretKey() {
+		byte[] decoded = Decoders.BASE64.decode(jwtProperties.getSecretKey());
+		this.secretKey = Keys.hmacShaKeyFor(decoded);
+	}
+
+	public String extractToken(HttpServletRequest request) {
+		String header = request.getHeader(JwtProperties.AUTHORIZATION_HEADER);
+
+		if (header == null || !header.startsWith(JwtProperties.TOKEN_PREFIX)) {
+			return null;
+		}
+		return header.split(" ")[1];
+	}
+
+	public TokenRespDto issueAccessToken(String email, String username) {
+		Instant issuedAt = Instant.now();
+		Instant expiration = issuedAt.plusMillis(jwtProperties.getAccessExpirationTime());
+		String token = buildJwtToken(email, username, issuedAt, expiration);
+
+		return TokenRespDto.builder()
+			.username(username)
+			.email(email)
+			.accessToken(token)
+			.build();
+	}
+
+	private String buildJwtToken(String email, String username, Instant issuedAt, Instant expiration) {
+		return Jwts.builder()
+			.setSubject(email)
+			.claim("username", username)
+			.claim("role", USER)
+			.setIssuedAt(Date.from(issuedAt))
+			.setExpiration(Date.from(expiration))
+			.signWith(secretKey)
+			.compact();
+	}
+
+	// JWT 토큰 검증
+	public Claims validateTokenAndGetClaims(String token) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(secretKey).build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			log.warn("Expired Token: {}", e.getMessage());
+			throw new JwtException(JwtErrorCode.EXPIRED_TOKEN);
+		} catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+			log.warn("Invalid Token: {}", e.getMessage());
+			throw new JwtException(JwtErrorCode.INVALID_TOKEN);
+		} catch (Exception e) {
+			log.error("Unexpected JWT Error: {}", e.getMessage());
+			throw new JwtException(JwtErrorCode.JWT_ERROR);
+		}
+	}
+
+	public Authentication getAuthentication(Claims claims) {
+		CustomUserDetails userDetails = new CustomUserDetails(
+			getSubject(claims), // email
+			getUsername(claims),
+			getAuthority(claims)
+		);
+
+		// 인증용 객체 생성
+		return new UsernamePasswordAuthenticationToken(
+			userDetails,
+			null,
+			userDetails.getAuthorities());
+	}
+
+	private String getSubject(Claims claims) { // 현재 subject -> email
+		return claims.getSubject();
+	}
+
+	private String getUsername(Claims claims) {
+		return claims.get("username", String.class);
+	}
+
+	private String getAuthority(Claims claims) {
+		return claims.get("role", String.class);
+	}
+}

--- a/src/main/java/com/goorm/LocC/auth/presentation/AuthController.java
+++ b/src/main/java/com/goorm/LocC/auth/presentation/AuthController.java
@@ -1,0 +1,30 @@
+package com.goorm.LocC.auth.presentation;
+
+import com.goorm.LocC.auth.application.AuthService;
+import com.goorm.LocC.auth.dto.TokenRespDto;
+import com.goorm.LocC.global.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "로그인", description = "로그인 관련 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/kakao")
+    @Operation(summary = "카카오 회원가입 및 로그인")
+    public ResponseEntity<ApiResponse<TokenRespDto>> kakaoLogin(
+            @Schema(description = "카카오 액세스 토큰", example = "Bearer bVF0Z136P6bHrZwEhOKJe21sOJtb9a_vAAAAAQo8IpsAAAGTRCyz-1XuKbObXTiX")
+            @RequestHeader("Kakao-Authorization") String kakaoAccessToken) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                authService.kakaoLogin(kakaoAccessToken)));
+    }
+}

--- a/src/main/java/com/goorm/LocC/auth/utils/KakaoProperties.java
+++ b/src/main/java/com/goorm/LocC/auth/utils/KakaoProperties.java
@@ -1,0 +1,16 @@
+package com.goorm.LocC.auth.utils;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoProperties {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String ID = "id";
+    public static final String ACCOUNT = "kakao_account";
+    public static final String PROFILE = "profile";
+    public static final String PROFILE_IMAGE_URL = "profile_image_url";
+    public static final String NICKNAME = "nickname";
+    public static final String EMAIL = "email";
+    public static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+}

--- a/src/main/java/com/goorm/LocC/curation/dto/CurationInfoDto.java
+++ b/src/main/java/com/goorm/LocC/curation/dto/CurationInfoDto.java
@@ -1,0 +1,27 @@
+package com.goorm.LocC.curation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CurationInfoDto {
+
+    @Schema(description = "큐레이션 ID", example = "1")
+    private Long curationId;
+    @Schema(description = "큐레이션 타이틀", example = "낙엽도 맛집이 있나요 TOP5")
+    private String title;
+    @Schema(description = "큐레이션 서브 타이틀", example = "낙엽이 떨어지기 직전인 지금 가봐야 할 서울 근교 낙엽 맛집")
+    private String subtitle;
+    @Schema(description = "큐레이션 이미지", example = "https://image.jpg")
+    private String imageUrl;
+
+    public CurationInfoDto(Long curationId, String title, String subtitle, String imageUrl) {
+        this.curationId = curationId;
+        this.title = title;
+        this.subtitle = subtitle;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/goorm/LocC/curation/repository/CurationBookmarkRepository.java
+++ b/src/main/java/com/goorm/LocC/curation/repository/CurationBookmarkRepository.java
@@ -3,6 +3,6 @@ package com.goorm.LocC.curation.repository;
 import com.goorm.LocC.curation.domain.CurationBookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CurationBookmarkRepository extends JpaRepository<CurationBookmark, Long> {
+public interface CurationBookmarkRepository extends JpaRepository<CurationBookmark, Long>, CurationBookmarkRepositoryCustom {
 
 }

--- a/src/main/java/com/goorm/LocC/curation/repository/CurationBookmarkRepositoryCustom.java
+++ b/src/main/java/com/goorm/LocC/curation/repository/CurationBookmarkRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.goorm.LocC.curation.repository;
+
+import com.goorm.LocC.curation.dto.CurationInfoDto;
+import com.goorm.LocC.member.dto.MemberCond;
+
+import java.util.List;
+
+public interface CurationBookmarkRepositoryCustom {
+
+    List<CurationInfoDto> searchCurationsByMember(MemberCond condition);
+}

--- a/src/main/java/com/goorm/LocC/curation/repository/CurationBookmarkRepositoryImpl.java
+++ b/src/main/java/com/goorm/LocC/curation/repository/CurationBookmarkRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.goorm.LocC.curation.repository;
+
+import com.goorm.LocC.curation.dto.CurationInfoDto;
+import com.goorm.LocC.member.domain.Member;
+import com.goorm.LocC.member.dto.MemberCond;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.goorm.LocC.curation.domain.QCuration.curation;
+import static com.goorm.LocC.curation.domain.QCurationBookmark.curationBookmark;
+
+@RequiredArgsConstructor
+public class CurationBookmarkRepositoryImpl implements CurationBookmarkRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<CurationInfoDto> searchCurationsByMember(MemberCond condition) {
+        return queryFactory
+                .select(
+                        Projections.constructor(CurationInfoDto.class,
+                                curation.curationId,
+                                curation.title,
+                                curation.subtitle,
+                                curation.imageUrl
+                        )
+                )
+                .from(curationBookmark)
+                .join(curationBookmark.curation, curation)
+                .where(memberEq(condition.getMember()))
+                .orderBy(curationBookmark.createdAt.desc())
+                .fetch();
+
+    }
+
+    private BooleanExpression memberEq(Member member) {
+        return member != null ? curationBookmark.member.eq(member) : null;
+    }
+}

--- a/src/main/java/com/goorm/LocC/global/common/utils/JsonResponseUtil.java
+++ b/src/main/java/com/goorm/LocC/global/common/utils/JsonResponseUtil.java
@@ -1,0 +1,26 @@
+package com.goorm.LocC.global.common.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JsonResponseUtil {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	public static void sendJsonResponse(HttpServletResponse response, HttpStatus httpStatus, Object body)
+		throws IOException {
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setStatus(httpStatus.value());
+		response.setCharacterEncoding("UTF-8");
+		String responseBody = objectMapper.writeValueAsString(body);
+		response.getWriter().write(responseBody);
+	}
+}

--- a/src/main/java/com/goorm/LocC/global/config/QuerydslConfig.java
+++ b/src/main/java/com/goorm/LocC/global/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.goorm.LocC.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/goorm/LocC/global/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/LocC/global/config/SecurityConfig.java
@@ -1,0 +1,56 @@
+package com.goorm.LocC.global.config;
+
+import com.goorm.LocC.auth.jwt.JwtAccessDeniedHandler;
+import com.goorm.LocC.auth.jwt.JwtAuthenticationEntryPoint;
+import com.goorm.LocC.auth.jwt.filter.JwtAuthenticationFilter;
+import com.goorm.LocC.auth.jwt.filter.JwtExceptionFilter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+	private final JwtExceptionFilter jwtExceptionFilter;
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+	private final String[] whitelist = {
+		"/",
+		"/api/v1/auth/**",
+		"/swagger-ui/**",
+		"/v3/api-docs/**"
+	};
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors(Customizer.withDefaults())
+			.formLogin(AbstractHttpConfigurer::disable)
+			.sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(request -> request
+				.requestMatchers(whitelist).permitAll()
+			.anyRequest().authenticated())
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+			.exceptionHandling(exceptions -> exceptions
+				.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+				.accessDeniedHandler(jwtAccessDeniedHandler)
+			);
+
+		return http.build();
+	}
+}

--- a/src/main/java/com/goorm/LocC/global/exception/BaseErrorCode.java
+++ b/src/main/java/com/goorm/LocC/global/exception/BaseErrorCode.java
@@ -10,9 +10,13 @@ public interface BaseErrorCode {
     String getCode();
     String getMessage();
 
+    default ApiResponse<Void> toApiResponse() {
+        return ApiResponse.failure(this);
+    }
+
     default ResponseEntity<ApiResponse<Void>> toResponseEntity() {
         return ResponseEntity
                 .status(getStatus())
-                .body(ApiResponse.failure(this));
+                .body(toApiResponse());
     }
 }

--- a/src/main/java/com/goorm/LocC/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goorm/LocC/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.goorm.LocC.global.exception;
 
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.goorm.LocC.auth.exception.AuthException;
 import com.goorm.LocC.global.common.dto.ApiResponse;
 import com.goorm.LocC.member.exception.MemberException;
+import com.goorm.LocC.review.exception.ReviewException;
 import com.goorm.LocC.store.exception.StoreException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -10,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @RestControllerAdvice
@@ -19,13 +23,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         Throwable cause = e.getCause();
 
-        log.warn(e.getMessage(), e);
+        log.warn("HttpMessageNotReadable Exception: {}", e.getMessage());
 
         if (cause instanceof ValueInstantiationException exception) {
             Throwable innerCause = exception.getCause(); // 내부 예외 확인
             if (innerCause instanceof BaseException baseException) {
                 return baseException.getErrorCode().toResponseEntity();
-
             }
         }
 
@@ -46,7 +49,28 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MemberException.class)
     public ResponseEntity<ApiResponse<Void>> handleMemberException(MemberException e) {
-        log.warn(e.getMessage(), e);
+        log.warn("Member Exception: {}", e.getMessage());
+
+        return e.getErrorCode().toResponseEntity();
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuthException(AuthException e) {
+        log.warn("Auth Exception: {}", e.getMessage());
+
+        return e.getErrorCode().toResponseEntity();
+    }
+
+    @ExceptionHandler(ReviewException.class)
+    public ResponseEntity<ApiResponse<Void>> handleReviewException(ReviewException e) {
+        log.warn("Review Exception: {}", e.getMessage());
+
+        return e.getErrorCode().toResponseEntity();
+    }
+
+    @ExceptionHandler(StoreException.class)
+    public ResponseEntity<ApiResponse<Void>> handleStoreException(StoreException e) {
+        log.warn("Store Exception: {}", e.getMessage());
 
         return e.getErrorCode().toResponseEntity();
     }
@@ -55,7 +79,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.warn(e.getMessage(), e);
 
-        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        HttpStatus status = INTERNAL_SERVER_ERROR;
         return ResponseEntity.internalServerError()
                 .body(ApiResponse.failure(String.valueOf(status.value()), status.getReasonPhrase()));
     }

--- a/src/main/java/com/goorm/LocC/member/application/MemberService.java
+++ b/src/main/java/com/goorm/LocC/member/application/MemberService.java
@@ -1,0 +1,41 @@
+package com.goorm.LocC.member.application;
+
+import com.goorm.LocC.curation.dto.CurationInfoDto;
+import com.goorm.LocC.curation.repository.CurationBookmarkRepository;
+import com.goorm.LocC.member.domain.Member;
+import com.goorm.LocC.member.dto.MemberCond;
+import com.goorm.LocC.member.dto.ProfileInfoRespDto;
+import com.goorm.LocC.member.exception.MemberException;
+import com.goorm.LocC.member.repository.MemberRepository;
+import com.goorm.LocC.store.dto.StoreInfoDto;
+import com.goorm.LocC.store.repository.StoreBookmarkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.goorm.LocC.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final CurationBookmarkRepository curationBookmarkRepository;
+    private final StoreBookmarkRepository storeBookmarkRepository;
+
+    public ProfileInfoRespDto getProfile(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        MemberCond condition = new MemberCond(member);
+        List<CurationInfoDto> curations = curationBookmarkRepository.searchCurationsByMember(condition);
+        List<StoreInfoDto> stores = storeBookmarkRepository.searchStoresByMember(condition);
+
+        return ProfileInfoRespDto.of(member, curations, stores);
+    }
+}

--- a/src/main/java/com/goorm/LocC/member/domain/Member.java
+++ b/src/main/java/com/goorm/LocC/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.goorm.LocC.member.domain;
 import com.goorm.LocC.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,10 +18,17 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SocialType socialType;
+
+    @Column(nullable = false, unique = true)
+    private String socialId;
+
     @Column(nullable = false)
     private String username;
 
-    private String profileImageUrl;
+    private String profileImageUrl = "";
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -28,4 +36,13 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false, unique = true)
     private String email;
+
+    @Builder
+    public Member(SocialType socialType, String socialId, String username, String profileImageUrl, String email) {
+        this.socialType = socialType;
+        this.socialId = socialId;
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+        this.email = email;
+    }
 }

--- a/src/main/java/com/goorm/LocC/member/domain/Member.java
+++ b/src/main/java/com/goorm/LocC/member/domain/Member.java
@@ -28,6 +28,9 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String username;
 
+    @Column(nullable = false, unique = true)
+    private String handle;
+
     private String profileImageUrl = "";
 
     @Enumerated(EnumType.STRING)
@@ -41,6 +44,7 @@ public class Member extends BaseEntity {
     public Member(SocialType socialType, String socialId, String username, String profileImageUrl, String email) {
         this.socialType = socialType;
         this.socialId = socialId;
+        this.handle = socialId; // 임시 지정
         this.username = username;
         this.profileImageUrl = profileImageUrl;
         this.email = email;

--- a/src/main/java/com/goorm/LocC/member/domain/SocialType.java
+++ b/src/main/java/com/goorm/LocC/member/domain/SocialType.java
@@ -1,0 +1,5 @@
+package com.goorm.LocC.member.domain;
+
+public enum SocialType {
+    KAKAO
+}

--- a/src/main/java/com/goorm/LocC/member/dto/MemberCond.java
+++ b/src/main/java/com/goorm/LocC/member/dto/MemberCond.java
@@ -1,0 +1,15 @@
+package com.goorm.LocC.member.dto;
+
+import com.goorm.LocC.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberCond {
+
+    Member member;
+}

--- a/src/main/java/com/goorm/LocC/member/dto/ProfileInfoRespDto.java
+++ b/src/main/java/com/goorm/LocC/member/dto/ProfileInfoRespDto.java
@@ -1,0 +1,47 @@
+package com.goorm.LocC.member.dto;
+
+import com.goorm.LocC.curation.dto.CurationInfoDto;
+import com.goorm.LocC.member.domain.Member;
+import com.goorm.LocC.store.dto.StoreInfoDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ProfileInfoRespDto {
+
+    @Schema(description = "닉네임", example = "미르미0303")
+    private String username;
+    @Schema(description = "아이디", example = "Mirmi")
+    private String handle;
+    @Schema(description = "프로필 이미지", example = "https://image.jpg")
+    private String profileImageUrl;
+    @Schema(description = "저장한 큐레이션 리스트")
+    private List<CurationInfoDto> savedCurations;
+    @Schema(description = "저장한 가게 리스트")
+    private List<StoreInfoDto> savedStores;
+
+    @Builder
+    public ProfileInfoRespDto(String username, String handle, String profileImageUrl, List<CurationInfoDto> savedCurations, List<StoreInfoDto> savedStores) {
+        this.username = username;
+        this.handle = handle;
+        this.profileImageUrl = profileImageUrl;
+        this.savedCurations = savedCurations;
+        this.savedStores = savedStores;
+    }
+
+    public static ProfileInfoRespDto of(Member member, List<CurationInfoDto> curations, List<StoreInfoDto> stores) {
+        return ProfileInfoRespDto.builder()
+                .username(member.getUsername())
+                .handle(member.getHandle())
+                .profileImageUrl(member.getProfileImageUrl())
+                .savedCurations(curations)
+                .savedStores(stores)
+                .build();
+    }
+}

--- a/src/main/java/com/goorm/LocC/member/presentation/MemberController.java
+++ b/src/main/java/com/goorm/LocC/member/presentation/MemberController.java
@@ -1,0 +1,32 @@
+package com.goorm.LocC.member.presentation;
+
+import com.goorm.LocC.auth.dto.CustomUserDetails;
+import com.goorm.LocC.global.common.dto.ApiResponse;
+import com.goorm.LocC.member.application.MemberService;
+import com.goorm.LocC.member.dto.ProfileInfoRespDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "회원", description = "회원 관련 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "마이페이지 조회")
+    @GetMapping("/me/profile")
+    public ResponseEntity<ApiResponse<ProfileInfoRespDto>> getProfile(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        return ResponseEntity.ok(ApiResponse.success(
+                memberService.getProfile(user.getEmail())
+        ));
+    }
+}

--- a/src/main/java/com/goorm/LocC/member/repository/MemberRepository.java
+++ b/src/main/java/com/goorm/LocC/member/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialId(String socialId);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/goorm/LocC/member/repository/MemberRepository.java
+++ b/src/main/java/com/goorm/LocC/member/repository/MemberRepository.java
@@ -3,5 +3,9 @@ package com.goorm.LocC.member.repository;
 import com.goorm.LocC.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findBySocialId(String socialId);
 }

--- a/src/main/java/com/goorm/LocC/store/domain/BusinessHour.java
+++ b/src/main/java/com/goorm/LocC/store/domain/BusinessHour.java
@@ -31,5 +31,5 @@ public class BusinessHour extends BaseEntity {
     private LocalTime closeTime;
 
     @Column(nullable = false)
-    private Boolean isClosed;
+    private Boolean isHoliday;
 }

--- a/src/main/java/com/goorm/LocC/store/domain/Province.java
+++ b/src/main/java/com/goorm/LocC/store/domain/Province.java
@@ -15,18 +15,18 @@ import static com.goorm.LocC.store.exception.StoreErrorCode.INVALID_PROVINCE_ENU
 @RequiredArgsConstructor
 public enum Province {
     SEOUL("서울"),
-    GYEONGGI("경기도"),
+    GYEONGGI("경기"),
     INCHEON("인천"),
-    GANGWON("강원도"),
+    GANGWON("강원"),
     DAEJEON("대전"),
-    CHUNGCHEONG("충청도"),
-    JEOLLA("전라도"),
+    CHUNGCHEONG("충청"),
+    JEOLLA("전라"),
     GWANGJU("광주"),
-    GYEONGSANG("경상도"),
+    GYEONGSANG("경상"),
     DAEGU("대구"),
     BUSAN("부산"),
     ULSAN("울산"),
-    JEJU("제주도"),
+    JEJU("제주"),
     ;
 
     private final String name;

--- a/src/main/java/com/goorm/LocC/store/domain/Store.java
+++ b/src/main/java/com/goorm/LocC/store/domain/Store.java
@@ -24,7 +24,8 @@ public class Store extends BaseEntity {
     private String name;
 
     @Column(nullable = false)
-    private String category;
+    @Enumerated(EnumType.STRING)
+    private Category category;
 
     @Column(nullable = false)
     private String address;
@@ -40,6 +41,8 @@ public class Store extends BaseEntity {
     private City city;
 
     private String homepageUrl;
+
+    private String thumbnailImageUrl;
 
     private float rating = 0;
 

--- a/src/main/java/com/goorm/LocC/store/dto/StoreInfoDto.java
+++ b/src/main/java/com/goorm/LocC/store/dto/StoreInfoDto.java
@@ -1,0 +1,58 @@
+package com.goorm.LocC.store.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.goorm.LocC.store.domain.Category;
+import com.goorm.LocC.store.domain.City;
+import com.goorm.LocC.store.domain.Province;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StoreInfoDto {
+
+    @Schema(description = "가게 ID", example = "1")
+    private Long storeId;
+    @Schema(description = "가게 이름", example = "로슈아커피")
+    private String name;
+    @Schema(description = "가게 카테고리", example = "카페")
+    private Category category;
+    @Schema(description = "가게 특별시/광역시/도", example = "경기")
+    private Province province;
+    @Schema(description = "가게 시/군/구", example = "양주시")
+    private City city;
+    @Schema(description = "가게 이미지", example = "https://image.jpg")
+    private String imageUrl;
+    @Schema(description = "리뷰 평점", example = "4.42")
+    private float rating;
+    @Schema(description = "리뷰 수", example = "273")
+    private int reviewCount;
+    @Schema(description = "영업 시작 시간", example = "06:00", type = "string")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime openTime;
+    @Schema(description = "영업 종료 시간", example = "21:00", type = "string")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalTime closeTime;
+    @Schema(description = "휴무일 여부", example = "false")
+    private Boolean isHoliday;
+
+    public StoreInfoDto(Long storeId, String name, Category category, Province province, City city, String imageUrl, float rating, int reviewCount, LocalTime openTime, LocalTime closeTime, Boolean isHoliday) {
+        this.storeId = storeId;
+        this.name = name;
+        this.category = category;
+        this.province = province;
+        this.city = city;
+        this.imageUrl = imageUrl;
+        this.rating = Math.round(rating * 100) / 100.0f;
+        this.reviewCount = reviewCount;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.isHoliday = isHoliday;
+    }
+}

--- a/src/main/java/com/goorm/LocC/store/repository/StoreBookmarkRepository.java
+++ b/src/main/java/com/goorm/LocC/store/repository/StoreBookmarkRepository.java
@@ -3,6 +3,6 @@ package com.goorm.LocC.store.repository;
 import com.goorm.LocC.store.domain.StoreBookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreBookmarkRepository extends JpaRepository<StoreBookmark, Long> {
+public interface StoreBookmarkRepository extends JpaRepository<StoreBookmark, Long>, StoreBookmarkRepositoryCustom {
 
 }

--- a/src/main/java/com/goorm/LocC/store/repository/StoreBookmarkRepositoryCustom.java
+++ b/src/main/java/com/goorm/LocC/store/repository/StoreBookmarkRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.goorm.LocC.store.repository;
+
+import com.goorm.LocC.member.dto.MemberCond;
+import com.goorm.LocC.store.dto.StoreInfoDto;
+
+import java.util.List;
+
+public interface StoreBookmarkRepositoryCustom {
+
+    List<StoreInfoDto> searchStoresByMember(MemberCond condition);
+}

--- a/src/main/java/com/goorm/LocC/store/repository/StoreBookmarkRepositoryImpl.java
+++ b/src/main/java/com/goorm/LocC/store/repository/StoreBookmarkRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.goorm.LocC.store.repository;
+
+import com.goorm.LocC.member.domain.Member;
+import com.goorm.LocC.member.dto.MemberCond;
+import com.goorm.LocC.store.dto.StoreInfoDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.goorm.LocC.store.domain.QBusinessHour.businessHour;
+import static com.goorm.LocC.store.domain.QStore.store;
+import static com.goorm.LocC.store.domain.QStoreBookmark.storeBookmark;
+
+@RequiredArgsConstructor
+public class StoreBookmarkRepositoryImpl implements StoreBookmarkRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<StoreInfoDto> searchStoresByMember(MemberCond condition) {
+        DayOfWeek today = LocalDate.now().getDayOfWeek();
+
+        return queryFactory
+                .select(
+                        Projections.constructor(StoreInfoDto.class,
+                                store.storeId,
+                                store.name,
+                                store.category,
+                                store.province,
+                                store.city,
+                                store.thumbnailImageUrl.as("imageUrl"),
+                                store.rating,
+                                store.reviewCount,
+                                businessHour.openTime,
+                                businessHour.closeTime,
+                                businessHour.isHoliday
+                        )
+                )
+                .from(storeBookmark)
+                .join(storeBookmark.store, store)
+                .on(bookmarkMemberEq(condition.getMember()))
+                .join(businessHour).on(
+                        businessHour.store.eq(store),
+                        businessHourDayEq(today))
+//                .where(memberEq(condition.getMember()))
+                .orderBy(storeBookmark.createdAt.desc())
+                .fetch();
+    }
+
+    private BooleanExpression bookmarkMemberEq(Member member) {
+        return member != null ? storeBookmark.member.eq(member) : null;
+    }
+
+    private BooleanExpression businessHourDayEq(DayOfWeek today) {
+        return today != null ? businessHour.dayOfWeek.eq(today) : null;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#3, #5 

## 💡 작업 내용

- 카카오 로그인
- jwt token 발급 및 인증/인가 로직
- spring security 세팅
- querydsl 세팅
- 마이페이지 정보 조회 기능

## 💬 리뷰 요구사항

- 피그마 디자인 마이페이지에 아이디도 있어서 Member entity에 handle 필드 추가했습니다.
- 저장한 가게의 경우 가게의 여러 사진이 아니라 대표로 보여줄 사진 하나만 제공해야해서 StoreImage 테이블에서 매번 가져오지 않고 Store에 thumbnailImageUrl라는 필드를 따로 하나 추가해서 대표 사진은 거기 저장하고 나머지 가게 사진들은 StoreImage 테이블에 저장하는 방향으로 생각했는데 더 좋은 의견 있을까요?

